### PR TITLE
[Test] LocalDateExtension 테스트 코드 작성하기 #4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,6 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
-
-        buildConfigField("String", "GOOGLD_AD_BANNER", GOOGLD_AD_BANNER)
     }
 
     buildTypes {
@@ -86,4 +84,7 @@ dependencies {
 
     // googld abs
     implementation 'com.google.android.gms:play-services-ads:21.3.0'
+
+    // test
+    testImplementation "org.hamcrest:hamcrest-all:1.1"
 }

--- a/app/src/main/java/com/haman/dearme/ui/components/common/Footer.kt
+++ b/app/src/main/java/com/haman/dearme/ui/components/common/Footer.kt
@@ -21,16 +21,6 @@ fun LazyListScope.footer(
 ) {
     item {
         Column {
-            AndroidView(
-                modifier = Modifier.fillMaxWidth(),
-                factory = {
-                    AdView(it).apply {
-                        setAdSize(AdSize.SMART_BANNER)
-                        adUnitId = BuildConfig.GOOGLD_AD_BANNER
-//                        adUnitId = "ca-app-pub-3940256099942544/6300978111"
-                        loadAd(AdRequest.Builder().build())
-                    }
-                })
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
+++ b/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
@@ -50,7 +50,7 @@ fun LocalDate.getYearAndMonth(): String {
     val year = this.year
     val month = this.month.value
 
-    return "$year/$month"
+    return "$year/${"%02d".format(month)}"
 }
 
 fun LocalDate.getTime() = this.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()

--- a/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
+++ b/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
@@ -40,6 +40,10 @@ fun LocalDateTime.timeFormat(): String {
     return this.format(formatter)
 }
 
+/**
+ * 해당 월의 마지막 날짜 반환
+ * ex. 1월 -> 31
+ */
 fun LocalDate.getLastDate() = this.withDayOfMonth(lengthOfMonth()).dayOfMonth
 
 fun LocalDate.getYearAndMonth(): String {

--- a/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
+++ b/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
@@ -36,7 +36,7 @@ fun LocalDateTime.dateFormat(): String {
 
 fun LocalDateTime.timeFormat(): String {
     val formatter: DateTimeFormatter =
-        DateTimeFormatter.ofPattern("a KK:mm", Locale.getDefault())
+        DateTimeFormatter.ofPattern("a hh:mm", Locale.getDefault())
     return this.format(formatter)
 }
 

--- a/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
+++ b/app/src/main/java/com/haman/dearme/util/ext/LocalDateExtension.kt
@@ -22,7 +22,7 @@ fun LocalDateTime.dayOfWeekText() =
 
 fun LocalDateTime.fullTimeFormat(): String {
     val formatter: DateTimeFormatter =
-        DateTimeFormatter.ofPattern("yyyy.MM.dd a KK:mm", Locale.KOREA)
+        DateTimeFormatter.ofPattern("yyyy.MM.dd a hh:mm", Locale.getDefault())
     return this.format(formatter)
 }
 

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -76,4 +76,14 @@ internal class LocalDateExtensionTest {
         // 3. Then
         assertThat(result, `is`("오후 12:59"))
     }
+
+    @Test
+    fun getLastDate_LocalDate_returnLastDate() {
+        // 1. Given
+        val date = LocalDate.of(2023,1,3)
+        // 2. When
+        val result = date.getLastDate()
+        // 3. Then
+        assertThat(result, `is`(31))
+    }
 }

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -52,4 +52,16 @@ internal class LocalDateExtensionTest {
         // 3. Then
         assertThat(result, `is`("2023.02.03 오후 12:59"))
     }
+
+    @Test
+    fun getDateFormat_LocalDateTime_returnYYYYDDDate() {
+        // 1. Given
+        val time = LocalDateTime.of(
+            2023, 2, 3, 12, 59
+        )
+        // 2. When
+        val result = time.dateFormat()
+        // 3. Then
+        assertThat(result, `is`("2월 3일 금요일"))
+    }
 }

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -40,4 +40,16 @@ internal class LocalDateExtensionTest {
         // 3. Then
         assertThat(result, `is`("금"))
     }
+
+    @Test
+    fun getFullTimeFormat_LocalDateTime_returnYYYYMMDDaKKmm() {
+        // 1. Given
+        val time = LocalDateTime.of(
+            2023, 2, 3, 12, 59
+        )
+        // 2. When
+        val result = time.fullTimeFormat()
+        // 3. Then
+        assertThat(result, `is`("2023.02.03 오후 12:59"))
+    }
 }

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -1,0 +1,3 @@
+package com.haman.dearme.util.ext
+
+internal class LocalDateExtensionTest

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -1,3 +1,20 @@
 package com.haman.dearme.util.ext
 
-internal class LocalDateExtensionTest
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.time.LocalDate
+
+internal class LocalDateExtensionTest {
+    @Test
+    fun getFullFormat_LocalDate_returnYYYYMMddDate() {
+        // 1. Given
+        val date = LocalDate.of(2023, 2, 3)
+
+        // 2. When
+        val result = date.fullFormat()
+
+        // 3. Then
+        assertThat(result, `is`("2023년 2월 3일 금요일"))
+    }
+}

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -86,4 +86,14 @@ internal class LocalDateExtensionTest {
         // 3. Then
         assertThat(result, `is`(31))
     }
+
+    @Test
+    fun getYearAndMonth_LocalDate_returnYYYYMM() {
+        // 1. Given
+        val date = LocalDate.of(2023,1,3)
+        // 2. When
+        val result = date.getYearAndMonth()
+        // 3. Then
+        assertThat(result, `is`("2023/01"))
+    }
 }

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 internal class LocalDateExtensionTest {
     @Test
@@ -24,6 +25,18 @@ internal class LocalDateExtensionTest {
         val date = LocalDate.of(2023, 2, 3)
         // 2. When
         val result = date.dayOfWeekText()
+        // 3. Then
+        assertThat(result, `is`("금"))
+    }
+
+    @Test
+    fun getDayOfWeekText_LocalDateTime_returnLocaleDefaultDate() {
+        // 1. Given
+        val time = LocalDateTime.of(
+            2023, 2, 3, 12, 59
+        )
+        // 2. When
+        val result = time.dayOfWeekText()
         // 3. Then
         assertThat(result, `is`("금"))
     }

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -42,7 +42,7 @@ internal class LocalDateExtensionTest {
     }
 
     @Test
-    fun getFullTimeFormat_LocalDateTime_returnYYYYMMDDaKKmm() {
+    fun getFullTimeFormat_LocalDateTime_returnYYYYMMDDaHHmm() {
         // 1. Given
         val time = LocalDateTime.of(
             2023, 2, 3, 12, 59
@@ -63,5 +63,17 @@ internal class LocalDateExtensionTest {
         val result = time.dateFormat()
         // 3. Then
         assertThat(result, `is`("2월 3일 금요일"))
+    }
+
+    @Test
+    fun getTimeFormat_LocalDateTime_returnHHmm() {
+        // 1. Given
+        val time = LocalDateTime.of(
+            2023, 2, 3, 12, 59
+        )
+        // 2. When
+        val result = time.timeFormat()
+        // 3. Then
+        assertThat(result, `is`("오후 12:59"))
     }
 }

--- a/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
+++ b/app/src/test/java/com/haman/dearme/util/ext/LocalDateExtensionTest.kt
@@ -17,4 +17,14 @@ internal class LocalDateExtensionTest {
         // 3. Then
         assertThat(result, `is`("2023년 2월 3일 금요일"))
     }
+
+    @Test
+    fun getDayOfWeekText_LocalDate_returnLocalDefaultDate() {
+        // 1. Given
+        val date = LocalDate.of(2023, 2, 3)
+        // 2. When
+        val result = date.dayOfWeekText()
+        // 3. Then
+        assertThat(result, `is`("금"))
+    }
 }


### PR DESCRIPTION
### 🌹 내용
LocalDateExtension 내에 정의된 메서드와 관련된 테스트 코드 작성하기

### 🍿 To Do
- [x] LocalDate.fullFormat()
- [x] LocalDate.dayOfWeekText()
- [x] LocalDateTime.dayOfWeekText()
- [x] LocalDateTime.fullTimeFormat()
- [x] LocalDateTime.dateFormat()
- [x] LocalDateTime.timeFormat()
- [x] LocalDate.getLastDate()
- [x] LocalDate.getYearAndMonth()

### 🔥 추가 수정사항
#### 1. [LocalDateTime.fullTimeFormat]
<img width="286" alt="스크린샷 2023-02-03 오후 10 15 04" src="https://user-images.githubusercontent.com/22411296/216613725-f51f34b2-c6df-4bb6-8312-7b8ca2d73662.png">

12:59이
- 오후 00:59로 출력되는 것을 확인
- 기획에 맞게 오후 12:59로 출력되도록 수정
```[kotlin]
fun LocalDateTime.fullTimeFormat(): String {
    // 원본
    val formatter: DateTimeFormatter =
        DateTimeFormatter.ofPattern("yyyy.MM.dd a KK:mm", Locale.KOREAN)
    // 수정
    val formatter: DateTimeFormatter =
        DateTimeFormatter.ofPattern("yyyy.MM.dd a hh:mm", Locale.getDefault())
    return this.format(formatter)
}
```

#### 2. [LocalDate.getYearAndMonth]
<img width="240" alt="스크린샷 2023-02-03 오후 10 39 03" src="https://user-images.githubusercontent.com/22411296/216617399-1589f34f-843c-4018-97a5-1fcd0df51644.png">

2023년 1월이
- 2023/1로 출력되는 것을 확인
- 기획에 맞게 2023/01로 출력되도록 수정
```[kotlin]
fun LocalDate.getYearAndMonth(): String {
    val year = this.year
    val month = this.month.value

    // 원본
    return "$year/$month"
    // 수정
    return "$year/${"%02d".format(month)}"
}
```

### 📌 관련 이슈
Closed #4 